### PR TITLE
Update setup-go to be able to cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,27 @@ on:
 
 jobs:
 
-  lint:
+  download:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21
+
+    - name: Download
+      run: go mod download
+
+  lint:
+    needs: download
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
       with:
         go-version: 1.21
         
@@ -30,12 +44,13 @@ jobs:
       run: if [ "$(gofmt -s -l -e . | wc -l)" -gt 0 ]; then exit 1; fi
 
   build:
+    needs: download
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.21
 
@@ -43,12 +58,13 @@ jobs:
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "-static"' -tags netgo -o validator cmd/validator/validator.go
 
   test:
+    needs: download
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.21
 


### PR DESCRIPTION
Fixes #73
setup-go can use cache default.

https://github.com/actions/setup-go#v4

